### PR TITLE
fixed null item crash and added support for comments elements

### DIFF
--- a/libs/rss-to-fullrss.js
+++ b/libs/rss-to-fullrss.js
@@ -146,10 +146,17 @@ RssToFullRss.prototype.getFeedProcessor = function(callback) {
       }
 
       items.forEach(function (item) {
-        // Fix disagreement between node-rss and feedparser about which
-        // property stores the article url.
-        item.url = item.link;
-        responseFeed.item(item);
+        if(item != null) {
+          // Fix disagreement between node-rss and feedparser about which
+          // property stores the article url.
+          item.url = item.link;
+
+          // set comments element in node-rss if it exists on the original
+          if(item.comments != null) {
+            item.custom_elements = [{'comments': item.comments}];
+          }
+          responseFeed.item(item);
+        }
       });
       callback(null, responseFeed.xml());
     };


### PR DESCRIPTION
I've run into a few feeds that were crashing on line 151 because some of the items being looped were null (for example, NPR's feed http://www.npr.org/rss/rss.php?id=1001), so I added check to skip null items in the original feed.

Additionally, I noticed that even when the original item contained a `<comments>` element (which is part of the RSS 2.0 spec), it was not getting copied over to the full text feed--it looks like `node-rss` doesn't support that element directly, so I set it as a `custom_elements` value to get it working.
